### PR TITLE
Add required graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "babylon": "^6.17.0",
+    "graphql": "^0.9.6",
     "graphql-tag": "^2.0.0",
     "resolve": "^1.3.3"
   },


### PR DESCRIPTION
Currently projects that don't have graphql as a root dependency do not work this this library